### PR TITLE
[fix] Fix relationships in typeorm adapter

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -5,6 +5,10 @@
     "next",
     "next-major",
     {
+      "name": "fix-relations",
+      "prerelease": "rc-mlt",
+    },
+    {
       "name": "beta",
       "prerelease": true
     }

--- a/.releaserc
+++ b/.releaserc
@@ -5,10 +5,6 @@
     "next",
     "next-major",
     {
-      "name": "fix-relations",
-      "prerelease": "rc-mlt",
-    },
-    {
       "name": "beta",
       "prerelease": true
     }

--- a/ormconfig.js
+++ b/ormconfig.js
@@ -2,7 +2,7 @@ module.exports = {
   type: 'postgres',
   host: process.env.POSTGRES_HOST || 'localhost',
   port: +(process.env.POSTGRES_PORT || 5432),
-  username: process.env.POSTGRES_USER || 'postgres',
+  username: process.env.POSTGRES_USER || '',
   password: process.env.POSTGRES_PASSWORD || '',
   database: process.env.POSTGRES_DATABASE || 'database_test',
   entities: ['spec/entities/**/*.ts'],

--- a/spec/Property.spec.ts
+++ b/spec/Property.spec.ts
@@ -23,9 +23,9 @@ describe('Property', () => {
 
   describe('#name', () => {
     it('returns a name of the property', () => {
-      const column = columns.find((c) => c.propertyName === 'id') as ColumnMetadata
+      const column = columns.find((c) => c.propertyName === 'carId') as ColumnMetadata
 
-      expect(new Property(column).name()).to.equal('id')
+      expect(new Property(column).name()).to.equal('carId')
     })
   })
 
@@ -37,7 +37,7 @@ describe('Property', () => {
     })
 
     it('returns the path of the property', () => {
-      const column = columns.find((c) => c.propertyName === 'carDealer') as ColumnMetadata
+      const column = columns.find((c) => c.propertyName === 'carDealerId') as ColumnMetadata
 
       expect(new Property(column).path()).to.equal('carDealerId')
     })
@@ -45,7 +45,7 @@ describe('Property', () => {
 
   describe('#isId', () => {
     it('returns true for primary key', () => {
-      const column = columns.find((c) => c.propertyName === 'id') as ColumnMetadata
+      const column = columns.find((c) => c.propertyName === 'carId') as ColumnMetadata
 
       expect(new Property(column).isId()).to.equal(true)
     })
@@ -59,7 +59,7 @@ describe('Property', () => {
 
   describe('#isEditable', () => {
     it('returns false for id field', async () => {
-      const column = columns.find((c) => c.propertyName === 'id') as ColumnMetadata
+      const column = columns.find((c) => c.propertyName === 'carId') as ColumnMetadata
 
       expect(new Property(column).isEditable()).to.equal(false)
     })
@@ -81,7 +81,7 @@ describe('Property', () => {
 
   describe('#reference', () => {
     it('returns the name of the referenced resource if any', () => {
-      const column = columns.find((c) => c.propertyName === 'carDealer') as ColumnMetadata
+      const column = columns.find((c) => c.propertyName === 'carDealerId') as ColumnMetadata
 
       expect(new Property(column).reference()).to.equal('CarDealer')
     })

--- a/spec/Resource.spec.ts
+++ b/spec/Resource.spec.ts
@@ -68,7 +68,6 @@ describe('Resource', () => {
 
   describe('#properties', () => {
     it('returns all the properties', () => {
-      console.log(resource.properties().map((p) => p.path()))
       expect(resource.properties()).to.have.lengthOf(13)
     })
 

--- a/spec/Resource.spec.ts
+++ b/spec/Resource.spec.ts
@@ -68,19 +68,20 @@ describe('Resource', () => {
 
   describe('#properties', () => {
     it('returns all the properties', () => {
-      expect(resource.properties()).to.have.lengthOf(12)
+      console.log(resource.properties().map((p) => p.path()))
+      expect(resource.properties()).to.have.lengthOf(13)
     })
 
     it('returns all properties with the correct position', () => {
       expect(resource.properties().map((property) => property.position())).to.deep.equal([
-        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
       ])
     })
   })
 
   describe('#property', () => {
     it('returns selected property', () => {
-      const property = resource.property('id')
+      const property = resource.property('carId')
 
       expect(property).to.be.an.instanceOf(BaseProperty)
     })
@@ -111,26 +112,26 @@ describe('Resource', () => {
       const params = await resource.create(data)
 
       // eslint-disable-next-line no-unused-expressions
-      expect(params.id).not.to.be.undefined
+      expect(params.carId).not.to.be.undefined
     })
 
     it('stores Column with defined name property', async () => {
       const params = await resource.create(data)
-      const storedRecord = await Car.findOne(params.id) as Car
+      const storedRecord = await Car.findOne(params.carId) as Car
 
       expect(storedRecord.streetNumber).to.equal(data.streetNumber)
     })
 
     it('stores number Column with property as string', async () => {
       const params = await resource.create(data)
-      const storedRecord = await Car.findOne(params.id) as Car
+      const storedRecord = await Car.findOne(params.carId) as Car
 
       expect(storedRecord.stringAge).to.equal(4)
     })
 
     it('stores mixed type properties', async () => {
       const params = await resource.create(data)
-      const storedRecord = await Car.findOne(params.id) as Car
+      const storedRecord = await Car.findOne(params.carId) as Car
 
       expect(storedRecord.meta).to.deep.equal({
         title: data['meta.title'],
@@ -186,7 +187,7 @@ describe('Resource', () => {
         age: 4,
         stringAge: '4',
       })
-      record = await resource.findOne(params.id)
+      record = await resource.findOne(params.carId)
     })
 
     it('updates record name', async () => {
@@ -233,10 +234,10 @@ describe('Resource', () => {
     it('creates new resource with uuid', async () => {
       carParams = await resource.create({
         ...data,
-        carBuyerId: carBuyer.id,
+        carBuyerId: carBuyer.carBuyerId,
       })
 
-      expect(carParams.carBuyerId).to.equal(carBuyer.id)
+      expect(carParams.carBuyerId).to.equal(carBuyer.carBuyerId)
     })
   })
 
@@ -251,12 +252,12 @@ describe('Resource', () => {
     })
 
     afterEach(async () => {
-      await Car.delete(carParams.id)
+      await Car.delete(carParams.carId)
       await CarDealer.delete(carDealer)
     })
 
     it('deletes the resource', async () => {
-      await resource.delete(carParams.id)
+      await resource.delete(carParams.carId)
       expect(await resource.count({} as Filter)).to.eq(0)
     })
 

--- a/spec/entities/Car.ts
+++ b/spec/entities/Car.ts
@@ -1,6 +1,6 @@
 import {
   Entity, Column, PrimaryGeneratedColumn, BaseEntity, ManyToOne,
-  RelationId, UpdateDateColumn, CreateDateColumn,
+  JoinColumn, UpdateDateColumn, CreateDateColumn, RelationId,
 } from 'typeorm'
 import { IsDefined, Min, Max } from 'class-validator'
 import { CarDealer } from './CarDealer'
@@ -15,7 +15,7 @@ export enum CarType {
 @Entity()
 export class Car extends BaseEntity {
   @PrimaryGeneratedColumn()
-  public id: number;
+  public carId: number;
 
   @Column()
   @IsDefined()
@@ -51,16 +51,23 @@ export class Car extends BaseEntity {
   public meta;
 
   @ManyToOne(() => CarDealer, (carDealer) => carDealer.cars)
+  @JoinColumn({
+    name: 'car_dealer_id',
+  })
   public carDealer: CarDealer;
 
-  @RelationId((car: Car) => car.carDealer)
+  @Column({ name: 'car_dealer_id', type: 'integer', nullable: true })
   public carDealerId: number;
 
   @ManyToOne(() => CarBuyer, (carBuyer) => carBuyer.cars)
+  // @JoinColumn({
+  //   name: 'car_buyer_id',
+  // })
   public carBuyer: CarBuyer;
 
+  @Column({ name: 'car_buyer_id', type: 'uuid', nullable: true })
   @RelationId((car: Car) => car.carBuyer)
-  public carBuyerId: number;
+  public carBuyerId: string;
 
   @CreateDateColumn({ name: 'created_at' })
   public createdAt: Date;

--- a/spec/entities/CarBuyer.ts
+++ b/spec/entities/CarBuyer.ts
@@ -5,7 +5,7 @@ import { Car } from './Car'
 @Entity()
 export class CarBuyer extends BaseEntity {
   @PrimaryGeneratedColumn('uuid')
-  public id: string;
+  public carBuyerId: string;
 
   @Column()
   @IsDefined()

--- a/src/Property.ts
+++ b/src/Property.ts
@@ -8,8 +8,7 @@ export class Property extends BaseProperty {
   private columnPosition: number;
 
   constructor(column: ColumnMetadata, columnPosition = 0) {
-    // for reference fields take database name (with ...Id)
-    const path = column.referencedColumn ? column.databaseName : column.propertyPath
+    const path = column.propertyPath
     super({ path })
     this.column = column
     this.columnPosition = columnPosition

--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -152,11 +152,15 @@ export class Resource extends BaseResource {
         if (param === null) {
           preparedParams[property.column.propertyName] = null
         } else {
+          const [ref, foreignKey] = property.column.propertyPath.split('.')
           const id = (property.column.type === Number) ? Number(param) : param
-          preparedParams[property.column.propertyName] = id
+          preparedParams[ref] = foreignKey ? {
+            [foreignKey]: id,
+          } : id
         }
       }
     })
+
     return preparedParams
   }
 

--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -152,13 +152,8 @@ export class Resource extends BaseResource {
         if (param === null) {
           preparedParams[property.column.propertyName] = null
         } else {
-          // references cannot be stored as an IDs in typeorm, so in order to mimic this) and
-          // not fetching reference resource) change this:
-          // { postId: "1" }
-          // to that:
-          // { post: { id: 1 } }
           const id = (property.column.type === Number) ? Number(param) : param
-          preparedParams[property.column.propertyName] = { id }
+          preparedParams[property.column.propertyName] = id
         }
       }
     })

--- a/src/utils/convertFilter.ts
+++ b/src/utils/convertFilter.ts
@@ -26,13 +26,8 @@ export function convertFilter(filter?: Filter): FindConditions<BaseEntity> {
     } else if ((one.property as Property).column.type === 'enum') {
       where[n] = one.value
     } else if ((one.property as Property).type() === 'reference') {
-      // when comes to reference TypeORM cannot filter by referenceId: YOUR_FILTER_VALUE
-      // I don't know why. But it filters by an object: reference: {id: YOUR_FILTER_VALUE}
-      // propertyPath holds `reference.id` that is why we split it by `.`
-      const [column, key] = (one.property as Property).column.propertyPath.split('.')
-      where[column] = {
-        [key]: one.value,
-      }
+      const [column] = (one.property as Property).column.propertyPath.split('.')
+      where[column] = one.value
     } else {
       where[n] = Like(`%${one.value}%`)
     }

--- a/src/utils/data-types.ts
+++ b/src/utils/data-types.ts
@@ -43,7 +43,7 @@ const DATE = [
   // WithPrecisionColumnType:
   'datetime', 'datetime2', 'datetimeoffset', 'time', 'time with time zone',
   'time without time zone', 'timestamp', 'timestamp without time zone',
-  'timestamp with time zone', 'timestamp with local time zone',
+  'timestamp with time zone', 'timestamp with local time zone', 'timestamptz',
 
   // SimpleColumnType:
   'timestamp with local time zone', 'smalldatetime', 'date',


### PR DESCRIPTION
This fixes:
1. Requiring to define `@RelationId` in entity definitions. Now it should be enough to create a relationship (i. e. `@ManyToOne` and `@JoinColumn`)
2. Added `timestamptz` to Date types
3. Primary keys with names different than `id` should now work