### PR TITLE
chore: rebrand AdminBro to AdminJS

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,5 +1,5 @@
-POSTGRES_USER="adminbro"
-POSTGRES_PASSWORD="adminbro"
-POSTGRES_DATABASE="adminbro-typeorm-app"
+POSTGRES_USER="adminjs"
+POSTGRES_PASSWORD="adminjs"
+POSTGRES_DATABASE="adminjs-typeorm-app"
 POSTGRES_PORT=5432
 POSTGRES_HOST="localhost"

--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,6 @@ dist
 types
 build
 lib
-.adminbro
+.adminjs
 
 example-app/cypress/videos

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-## admin-bro-typeorm
+## adminjs-typeorm
 
-This is an official [admin-bro](https://github.com/SoftwareBrothers/admin-bro) adapter which integrates [TypeORM](https://typeorm.io/) into admin-bro. (originally forked from [Arteha/admin-bro-typeorm](https://github.com/Arteha/admin-bro-typeorm))
+This is an official [AdminJS](https://github.com/SoftwareBrothers/adminjs) adapter which integrates [TypeORM](https://typeorm.io/) into AdminJS. (originally forked from [Arteha/admin-bro-typeorm](https://github.com/Arteha/admin-bro-typeorm))
 
-Installation: `yarn add @admin-bro/typeorm`
+Installation: `yarn add @adminjs/typeorm`
 
 ## Usage
 
-The plugin can be registered using standard `AdminBro.registerAdapter` method.
-o
-```typescript
-import { Database, Resource } from '@admin-bro/typeorm'
-import AdminBro from 'admin-bro'
+The plugin can be registered using standard `AdminJS.registerAdapter` method.
 
-AdminBro.registerAdapter({ Database, Resource });
+```typescript
+import { Database, Resource } from '@adminjs/typeorm'
+import AdminJS from 'adminjs'
+
+AdminJS.registerAdapter({ Database, Resource });
 
 // optional: if you use class-validator you have to inject this to resource.
 import { validate } from 'class-validator'
@@ -23,67 +23,67 @@ Resource.validate = validate
 
 ```typescript
 import {
-    BaseEntity,
-    Entity, PrimaryGeneratedColumn, Column,
-    createConnection,
-    ManyToOne,
-    RelationId
+  BaseEntity,
+  Entity, PrimaryGeneratedColumn, Column,
+  createConnection,
+  ManyToOne,
+  RelationId
 } from 'typeorm'
 import * as express from 'express'
-import { Database, Resource } from '@admin-bro/typeorm'
+import { Database, Resource } from '@adminjs/typeorm'
 import { validate } from 'class-validator'
 
-import AdminBro from 'admin-bro'
-import * as AdminBroExpress from '@admin-bro/express'
+import AdminJS from 'adminjs'
+import * as AdminJSExpress from '@adminjs/express'
 
 Resource.validate = validate
-AdminBro.registerAdapter({ Database, Resource })
+AdminJS.registerAdapter({ Database, Resource })
 
 @Entity()
 export class Person extends BaseEntity
 {
-    @PrimaryGeneratedColumn()
-    public id: number;
-    
-    @Column({type: 'varchar'})
-    public firstName: string;
-    
-    @Column({type: 'varchar'})
-    public lastName: string;
+  @PrimaryGeneratedColumn()
+  public id: number;
 
-    @ManyToOne(type => CarDealer, carDealer => carDealer.cars)
-    organization: Organization;
+  @Column({type: 'varchar'})
+  public firstName: string;
 
-    // in order be able to fetch resources in admin-bro - we have to have id available
-    @RelationId((person: Person) => person.organization)
-    organizationId: number;
-    
-    // For fancy clickable relation links:
-    public toString(): string
-    {
-        return `${firstName} ${lastName}`;
-    }
+  @Column({type: 'varchar'})
+  public lastName: string;
+
+  @ManyToOne(type => CarDealer, carDealer => carDealer.cars)
+  organization: Organization;
+
+  // in order be able to fetch resources in adminjs - we have to have id available
+  @RelationId((person: Person) => person.organization)
+  organizationId: number;
+
+  // For fancy clickable relation links:
+  public toString(): string
+  {
+    return `${firstName} ${lastName}`;
+  }
 }
 
 ( async () =>
 {
-    const connection = await createConnection({/* ... */})
-    
-    // Applying connection to model
-    Person.useConnection(connection)
-    
-    const adminBro = new AdminBro({
-        // databases: [connection],
-        resources: [
-            { resource: Person, options: { parent: { name: 'foobar' } } }
-        ], 
-        rootPath: '/admin',
-    })
-    
-    const app = express()
-    const router = AdminBroExpress.buildRouter(adminBro)
-    app.use(adminBro.options.rootPath, router)
-    app.listen(3000)
+  const connection = await createConnection({/* ... */})
+
+  // Applying connection to model
+  Person.useConnection(connection)
+
+  const adminJs = new AdminJS({
+    // databases: [connection],
+    resources: [
+      { resource: Person, options: { parent: { name: 'foobar' } } }
+      ],
+    rootPath: '/admin',
+  })
+
+  const app = express()
+  const router = AdminJSExpress.buildRouter(adminJs)
+  app.use(adminJs.options.rootPath, router)
+  app.listen(3000)
 })()
 ```
 
@@ -112,15 +112,15 @@ yarn link
 
 4. Setup example app
 
-Install all dependencies and use previously linked version of `@admin-bro/typeorm`.
+Install all dependencies and use previously linked version of `@adminjs/typeorm`.
 
 ```
 cd example-app
 yarn install
-yarn link @admin-bro/typeorm
+yarn link @adminjs/typeorm
 ```
 
-Optionally you might want to link your local version of `admin-bro` package
+Optionally you might want to link your local version of `adminjs` package
 
 5. Make sure you have all the envs set (which are defined in `example-app/ormconfig.js`)
 

--- a/example-app/.env-example
+++ b/example-app/.env-example
@@ -1,5 +1,5 @@
-POSTGRES_USER="adminbro"
-POSTGRES_PASSWORD="adminbro"
-POSTGRES_DATABASE="adminbro-typeorm-app"
+POSTGRES_USER="adminjs"
+POSTGRES_PASSWORD="adminjs"
+POSTGRES_DATABASE="adminjs-typeorm-app"
 POSTGRES_PORT=5432
 POSTGRES_HOST="localhost"

--- a/example-app/package.json
+++ b/example-app/package.json
@@ -1,33 +1,33 @@
 {
-   "name": "example-app",
-   "version": "1.0.0",
-   "main": "index.js",
-   "license": "MIT",
-   "scripts": {
-      "build": "tsc",
-      "start": "node build/src/index.js",
-      "dev": "yarn build && concurrently \"yarn build --watch\" \"nodemon --ext '.js' --watch ../lib --watch ./build --ignore 'cypress/**/*.js' node build/src/index.js\"",
-      "cypress:open": "cypress open",
-      "cypress:run": "cypress run"
-   },
-   "devDependencies": {
-      "@types/express": "^4.17.7",
-      "@types/node": "^8.0.29",
-      "concurrently": "^5.2.0",
-      "cypress": "^4.11.0",
-      "nodemon": "^2.0.4",
-      "ts-node": "3.3.0",
-      "typescript": "3.9.7"
-   },
-   "dependencies": {
-      "admin-bro": "^3.3.1",
-      "@admin-bro/express": "^3.0.0",
-      "@admin-bro/typeorm": "^1.0.1",
-      "express": "^4.17.1",
-      "express-formidable": "^1.2.0",
-      "express-session": "^1.17.1",
-      "pg": "^8.3.0",
-      "reflect-metadata": "^0.1.10",
-      "typeorm": "0.2.28"
-   }
+  "name": "example-app",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "scripts": {
+    "build": "tsc",
+    "start": "node build/src/index.js",
+    "dev": "yarn build && concurrently \"yarn build --watch\" \"nodemon --ext '.js' --watch ../lib --watch ./build --ignore 'cypress/**/*.js' node build/src/index.js\"",
+    "cypress:open": "cypress open",
+    "cypress:run": "cypress run"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.7",
+    "@types/node": "^8.0.29",
+    "concurrently": "^5.2.0",
+    "cypress": "^4.11.0",
+    "nodemon": "^2.0.4",
+    "ts-node": "3.3.0",
+    "typescript": "3.9.7"
+  },
+  "dependencies": {
+    "adminjs": "^3.3.1",
+    "@adminjs/express": "^3.0.0",
+    "@adminjs/typeorm": "^1.0.1",
+    "express": "^4.17.1",
+    "express-formidable": "^1.2.0",
+    "express-session": "^1.17.1",
+    "pg": "^8.3.0",
+    "reflect-metadata": "^0.1.10",
+    "typeorm": "0.2.28"
+  }
 }

--- a/example-app/src/entity/Car.ts
+++ b/example-app/src/entity/Car.ts
@@ -22,7 +22,7 @@ export class Car extends BaseEntity {
   @ManyToOne((type) => Seller, (seller) => seller.cars)
   seller: User;
 
-  // in order be able to fetch resources in admin-bro - we have to have id available
+  // in order be able to fetch resources in adminjs - we have to have id available
   @RelationId((car: Car) => car.owner)
   ownerId: number;
 

--- a/example-app/src/index.ts
+++ b/example-app/src/index.ts
@@ -1,21 +1,21 @@
 import 'reflect-metadata'
 import { createConnection } from 'typeorm'
 import express from 'express'
-import AdminBro from 'admin-bro'
-import { buildRouter } from '@admin-bro/express'
-import * as TypeormAdapter from '@admin-bro/typeorm'
+import AdminJS from 'adminjs'
+import { buildRouter } from '@adminjs/express'
+import * as TypeormAdapter from '@adminjs/typeorm'
 import { User } from './entity/User'
 import { Car } from './entity/Car'
 import { Seller } from './entity/Seller'
 
-AdminBro.registerAdapter(TypeormAdapter)
+AdminJS.registerAdapter(TypeormAdapter)
 
 const PORT = 3000
 
 const run = async () => {
   await createConnection()
   const app = express()
-  const admin = new AdminBro({
+  const admin = new AdminJS({
     resources: [{
       resource: User,
       options: {

--- a/example-app/tsconfig.json
+++ b/example-app/tsconfig.json
@@ -1,28 +1,28 @@
 {
   "compilerOptions": {
-      "baseUrl": ".",
-      "outDir": "./build",
-      "target": "es6",
-      "esModuleInterop": true,
-      "jsx": "react",
-      "strictNullChecks": true,
-      "strictFunctionTypes": true,
-      "strictBindCallApply": true,
-      "noImplicitThis": true,
-      "moduleResolution": "node",
-      "module": "commonjs",
-      "types": ["cypress"],
-      "emitDecoratorMetadata": true,
-      "experimentalDecorators": true,
-      "strictPropertyInitialization": false,
-      "sourceMap": true,
-      "paths": {
-        "react": ["node_modules/@types/react"],
-        "admin-bro": ["node_modules/admin-bro"],
-      }
+    "baseUrl": ".",
+    "outDir": "./build",
+    "target": "es6",
+    "esModuleInterop": true,
+    "jsx": "react",
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "noImplicitThis": true,
+    "moduleResolution": "node",
+    "module": "commonjs",
+    "types": ["cypress"],
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "sourceMap": true,
+    "paths": {
+      "react": ["node_modules/@types/react"],
+      "adminjs": ["node_modules/adminjs"]
+    }
   },
   "include": [
-      "./src/**/*",
-      "./cypress/**/*"
+    "./src/**/*",
+    "./cypress/**/*"
   ],
 }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@admin-bro/typeorm",
+  "name": "@adminjs/typeorm",
   "version": "1.4.0",
-  "description": "TypeORM adapter for AdminBro",
+  "description": "TypeORM adapter for AdminJS",
   "keywords": [
     "typeorm",
     "provider",
-    "admin-bro",
+    "adminjs",
     "orm admin",
     "typeorm admin",
     "admin panel"
@@ -25,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/SoftwareBrothers/admin-bro-typeorm.git"
+    "url": "git+https://github.com/SoftwareBrothers/adminjs-typeorm.git"
   },
   "husky": {
     "hooks": {
@@ -35,7 +35,7 @@
   "author": "Artem Zabolotnyi <1arteha1@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "admin-bro": "^3.3.1",
+    "adminjs": "^3.3.1",
     "typeorm": ">=0.2.28"
   },
   "optionalDependencies": {},
@@ -43,7 +43,7 @@
     "@types/chai": "^4.2.4",
     "@types/mocha": "^5.2.7",
     "@types/node": "12.0.10",
-    "admin-bro": "^3.3.1",
+    "adminjs": "^3.3.1",
     "chai": "^4.2.0",
     "class-validator": "^0.11.0",
     "mocha": "^6.2.2",

--- a/spec/Resource.spec.ts
+++ b/spec/Resource.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { BaseProperty, BaseRecord, ValidationError, Filter } from 'admin-bro'
+import { BaseProperty, BaseRecord, ValidationError, Filter } from 'adminjs'
 import { validate } from 'class-validator'
 
 import { Car } from './entities/Car'

--- a/src/Database.ts
+++ b/src/Database.ts
@@ -1,6 +1,6 @@
 import { Connection, BaseEntity } from 'typeorm'
 
-import { BaseDatabase } from 'admin-bro'
+import { BaseDatabase } from 'adminjs'
 import { Resource } from './Resource'
 
 export class Database extends BaseDatabase {

--- a/src/Property.ts
+++ b/src/Property.ts
@@ -1,5 +1,5 @@
 import { ColumnMetadata } from 'typeorm/metadata/ColumnMetadata'
-import { BaseProperty, PropertyType } from 'admin-bro'
+import { BaseProperty, PropertyType } from 'adminjs'
 import { DATA_TYPES } from './utils/data-types'
 
 export class Property extends BaseProperty {

--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign */
 import { BaseEntity } from 'typeorm'
-import { BaseResource, ValidationError, Filter, BaseRecord, flat } from 'admin-bro'
+import { BaseResource, ValidationError, Filter, BaseRecord, flat } from 'adminjs'
 
 import { Property } from './Property'
 import { convertFilter } from './utils/convertFilter'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,26 +1,26 @@
 /**
- * @module @admin-bro/typeorm
+ * @module @adminjs/typeorm
  * @subcategory Adapters
  * @section modules
  *
  * @classdesc
- * Database adapter which integrates [TypeORM](https://typeorm.io/) into admin-bro
+ * Database adapter which integrates [TypeORM](https://typeorm.io/) into adminjs
  *
  * ## installation
  *
  * ```
- * yarn add @admin-bro/typeorm
+ * yarn add @adminjs/typeorm
  * ```
  *
  * ## Usage
  *
- * The plugin can be registered using standard `AdminBro.registerAdapter` method.
+ * The plugin can be registered using standard `AdminJS.registerAdapter` method.
  *
  * ```
- * import { Database, Resource } from '@admin-bro/typeorm';
- * import AdminBro from 'admin-bro'
+ * import { Database, Resource } from '@adminjs/typeorm';
+ * import AdminJS from 'adminjs'
  *
- * AdminBro.registerAdapter(TypeOrmAdapter);
+ * AdminJS.registerAdapter(TypeOrmAdapter);
  *
  * //...
  * ```
@@ -47,14 +47,14 @@
  *     RelationId
  * } from 'typeorm';
  * import * as express from 'express';
- * import { Database, Resource } from '@admin-bro/typeorm';
+ * import { Database, Resource } from '@adminjs/typeorm';
  * import { validate } from 'class-validator'
  *
- * import AdminBro from 'admin-bro';
- * import * as AdminBroExpress from '@admin-bro/express'
+ * import AdminJS from 'adminjs';
+ * import * as AdminJSExpress from '@adminjs/express'
  *
  * Resource.validate = validate;
- * AdminBro.registerAdapter({ Database, Resource });
+ * AdminJS.registerAdapter({ Database, Resource });
  *
  * \@Entity()
  * export class Person extends BaseEntity
@@ -71,7 +71,7 @@
  *     \@ManyToOne(type => CarDealer, carDealer => carDealer.cars)
  *     organization: Organization;
  *
- *     // in order be able to fetch resources in admin-bro - we have to have id available
+ *     // in order be able to fetch resources in adminjs - we have to have id available
  *     \@RelationId((person: Person) => person.organization)
  *     organizationId: number;
  * }
@@ -83,7 +83,7 @@
  *     // Applying connection to model
  *     Person.useConnection(connection);
  *
- *     const adminBro = new AdminBro({
+ *     const adminJs = new AdminJS({
  *         // databases: [connection],
  *         resources: [
  *             { resource: Person, options: { parent: { name: 'foobar' } } }
@@ -92,8 +92,8 @@
  *     });
  *
  *     const app = express();
- *     const router = AdminBroExpress.buildRouter(adminBro);
- *     app.use(adminBro.options.rootPath, router);
+ *     const router = AdminJSExpress.buildRouter(adminJs);
+ *     app.use(adminJs.options.rootPath, router);
  *     app.listen(3000);
  * })();
  * ```

--- a/src/utils/convertFilter.ts
+++ b/src/utils/convertFilter.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, FindConditions, Between, MoreThanOrEqual, LessThanOrEqual, Like } from 'typeorm'
-import { Filter } from 'admin-bro'
+import { Filter } from 'adminjs'
 import { Property } from '../Property'
 
 function safeParseJSON(json: string) {

--- a/src/utils/data-types.ts
+++ b/src/utils/data-types.ts
@@ -1,4 +1,4 @@
-import { PropertyType } from 'admin-bro'
+import { PropertyType } from 'adminjs'
 
 export type DataType = 'string' | 'number' | 'float' | 'datetime' | 'date'
   | 'array' | 'object' | 'boolean';


### PR DESCRIPTION
This commit is a part of AdminBro to AdminJS process.
BREAKING CHANGE: AdminBro has been rebranded to AdminJS. All package and repository names had been updated.
# Migration Guide
1. Update your dependencies to use new `adminjs` packages.
- `admin-bro` -> `adminjs` for the core package
- `@admin-bro/<package name>` -> `@adminjs/<package name>` for other modules
2. Update your custom CSS classes:
- `.admin-bro_<component name>` -> `.adminjs_<component name>` (example: `.adminjs_Box`)
3. Search your project for `admin-bro` occurrences - most likely they will have to be updated to `adminjs`