### PR TITLE
feat: add support for soft deleted entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,26 @@ export class Person extends BaseEntity
 
 Admin supports ManyToOne relationship but you also have to define @RealationId as stated in the example above.
 
+## Get soft deleted entities
+
+Sometimes you might want to find entities that soft deleted. You can extend the existing entity with `withDeleted` property:
+
+```
+@Entity()
+export class Person extends BaseEntity {
+  @DeleteDateColumn()
+  deletedAt: Date|null;
+}
+
+// admin person model
+@Entity('person')
+export class AdminPagePerson extends Person {
+  static withDeleted = true
+}
+```
+
+You can pass `AdminPagePerson` to the resource configuration to include soft deleted entities in the query builder.
+
 ## Contribution
 
 ### Running the example app

--- a/spec/Database.spec.ts
+++ b/spec/Database.spec.ts
@@ -22,7 +22,7 @@ describe('Database', () => {
 
   describe('#resources', () => {
     it('returns all entities', async () => {
-      expect(new Database(dataSource).resources()).to.have.lengthOf(3)
+      expect(new Database(dataSource).resources()).to.have.lengthOf(4)
     })
   })
 })

--- a/spec/entities/Car.ts
+++ b/spec/entities/Car.ts
@@ -1,6 +1,6 @@
 import {
   Entity, Column, PrimaryGeneratedColumn, BaseEntity, ManyToOne,
-  JoinColumn, UpdateDateColumn, CreateDateColumn, RelationId,
+  JoinColumn, UpdateDateColumn, CreateDateColumn, RelationId, DeleteDateColumn,
 } from 'typeorm'
 import { IsDefined, Min, Max } from 'class-validator'
 import { CarDealer } from './CarDealer'
@@ -74,4 +74,7 @@ export class Car extends BaseEntity {
 
   @UpdateDateColumn({ name: 'updated_at' })
   public updatedAt: Date;
+
+  @DeleteDateColumn({ name: 'deleted_at' })
+  public deletedAt: Date;
 }

--- a/spec/entities/CarWithDeleted.ts
+++ b/spec/entities/CarWithDeleted.ts
@@ -1,0 +1,7 @@
+import { Entity } from 'typeorm'
+import { Car } from './Car'
+
+@Entity('car')
+export class CarWithDeleted extends Car {
+  static withDeleted = true
+}


### PR DESCRIPTION
Handles https://github.com/SoftwareBrothers/adminjs-typeorm/issues/54

Sometimes you might want to find entities that soft deleted. You can extend the existing entity with `withDeleted` property:

```
@Entity()
export class Person extends BaseEntity {
  @DeleteDateColumn()
  deletedAt: Date|null;
}
// admin person model
@Entity('person')
export class AdminPagePerson extends Person {
  static withDeleted = true

  // or method
  static withDeleted() {
    return true
  }
}
```

If model's `withDeleted` is true or a function that returns true, then `Resource` class will add `withDeleted: true` param to the all typeorm repository methods.