### PR TITLE
fix: change member variables visibility

### DIFF
--- a/src/Property.ts
+++ b/src/Property.ts
@@ -5,7 +5,7 @@ import { DATA_TYPES } from './utils/data-types'
 export class Property extends BaseProperty {
   public column: ColumnMetadata;
 
-  private columnPosition: number;
+  protected columnPosition: number;
 
   constructor(column: ColumnMetadata, columnPosition = 0) {
     const path = column.propertyPath

--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -11,9 +11,9 @@ type ParamsType = Record<string, any>;
 export class Resource extends BaseResource {
   public static validate: any;
 
-  private model: typeof BaseEntity;
+  protected model: typeof BaseEntity;
 
-  private propsObject: Record<string, Property> = {};
+  protected propsObject: Record<string, Property> = {};
 
   constructor(model: typeof BaseEntity) {
     super(model)
@@ -135,7 +135,7 @@ export class Resource extends BaseResource {
     }
   }
 
-  private prepareProps() {
+  protected prepareProps() {
     const { columns } = this.model.getRepository().metadata
     return columns.reduce((memo, col, index) => {
       const property = new Property(col, index)
@@ -147,7 +147,7 @@ export class Resource extends BaseResource {
   }
 
   /** Converts params from string to final type */
-  private prepareParams(params: Record<string, any>): Record<string, any> {
+  protected prepareParams(params: Record<string, any>): Record<string, any> {
     const preparedParams: Record<string, any> = { ...params }
 
     this.properties().forEach((property) => {


### PR DESCRIPTION
**Overview**

Change all private member variable visibility to protected so that library consumers can extend and switch adapter behavior to meet their needs.

I wanted to [add support for soft deleted entities](https://github.com/SoftwareBrothers/adminjs-typeorm/pull/55)  in our application but I wasn't able to customize the adapter because the classes have private members.

