### PR TITLE
feat: add support for load package via require()

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "exports": {
     ".": {
       "import": "./lib/index.js",
+      "require": "./lib/index.js",
       "types": "./lib/index.d.ts"
     }
   },


### PR DESCRIPTION
With Node.js's new experimental flag `--experimental-require-module` it is possible to `require()` ECMAScript modules into CommonJS. For more information, see the [Node.js documentation](https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require).

However without having `require` added to the `exports`  the `cjs` loader throws `Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in .../node_modules/@adminjs/typeorm/package.json`

To resolve the issue, `require` path added to the `package.json`.